### PR TITLE
[feature] Make it possible to perform database migration

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,45 @@
+name: Migration
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - migrations/**
+
+jobs:
+  migration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Configure
+        run: |
+          cat <<EOF > wrangler.toml
+          [[d1_databases]]
+          binding = "DB"
+          database_id = "${{ secrets.CLOUDFLARE_D1_PREVIEW_ID }}"
+          database_name = "preview"
+
+          [[d1_databases]]
+          binding = "DB"
+          database_id = "${{ secrets.CLOUDFLARE_D1_PRODUCTION_ID }}"
+          database_name = "production"
+          EOF
+
+# TODO: migration does not work with GitHubActions.
+# @see: https://github.com/cloudflare/workers-sdk/issues/3598
+
+#      - name: Migrate preview
+#        run: echo y | pnpm wrangler d1 migrations apply preview
+#        env:
+#          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+#      - name: Migrate production
+#        run: pnpm wrangler d1 migrations apply production
+#        env:
+#          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ next-env.d.ts
 
 # storybook
 /public/storybook
+
+# Wrangler
+.wrangler

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'drizzle-kit';
+
+export default {
+  schema: './src/app/_libs/db/schema/tables/*',
+  out: './migrations',
+} satisfies Config;

--- a/migrations/0000_unique_lilith.sql
+++ b/migrations/0000_unique_lilith.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text
+);

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,37 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "df51eed9-d579-4989-a300-ca287018029d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1689333490720,
+      "tag": "0000_unique_lilith",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "create:component": "scaffdog generate component",
     "dev": "next dev",
-    "dev:proxy": "cf-bindings-proxy --d1=DB",
+    "dev:proxy": "cf-bindings-proxy",
     "dev:storybook": "storybook dev",
     "build": "next build",
     "build:storybook": "storybook build -o public/storybook && mv public/storybook/index.html public/storybook/index.htm",
     "build:pages": "next-on-pages",
-    "build:ci": "pnpm run build:storybook && pnpm run build:pages"
+    "build:ci": "pnpm run build:storybook && pnpm run build:pages",
+    "migrate:create": "drizzle-kit generate:sqlite",
+    "migrate:apply": "wrangler d1 migrations apply local --local"
   },
   "pnpm": {
     "overrides": {
@@ -54,6 +56,7 @@
     "@vanilla-extract/next-plugin": "2.1.3",
     "@vanilla-extract/recipes": "0.4.0",
     "@vanilla-extract/webpack-plugin": "2.2.0",
+    "better-sqlite3": "8.4.0",
     "drizzle-kit": "0.19.9",
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ dependencies:
     version: 2.0.0
   drizzle-orm:
     specifier: 0.27.2
-    version: 0.27.2(@cloudflare/workers-types@4.20230717.0)
+    version: 0.27.2(@cloudflare/workers-types@4.20230717.0)(better-sqlite3@8.4.0)
   modern-normalize:
     specifier: 2.0.0
     version: 2.0.0
@@ -105,6 +105,9 @@ devDependencies:
   '@vanilla-extract/webpack-plugin':
     specifier: 2.2.0
     version: 2.2.0(@types/node@20.4.2)(webpack@5.88.1)
+  better-sqlite3:
+    specifier: 8.4.0
+    version: 8.4.0
   drizzle-kit:
     specifier: 0.19.9
     version: 0.19.9
@@ -7114,7 +7117,7 @@ packages:
       - supports-color
     dev: true
 
-  /drizzle-orm@0.27.2(@cloudflare/workers-types@4.20230717.0):
+  /drizzle-orm@0.27.2(@cloudflare/workers-types@4.20230717.0)(better-sqlite3@8.4.0):
     resolution: {integrity: sha512-ZvBvceff+JlgP7FxHKe0zOU9CkZ4RcOtibumIrqfYzDGuOeF0YUY0F9iMqYpRM7pxnLRfC+oO7rWOUH3T5oFQA==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -7177,6 +7180,7 @@ packages:
         optional: true
     dependencies:
       '@cloudflare/workers-types': 4.20230717.0
+      better-sqlite3: 8.4.0
     dev: false
 
   /duplexer3@0.1.5:

--- a/src/app/_libs/db/index.ts
+++ b/src/app/_libs/db/index.ts
@@ -1,5 +1,6 @@
 import { drizzle } from 'drizzle-orm/d1';
 
+import { schema } from './schema';
 import { env } from '../env';
 
-export const db = drizzle(env.DB);
+export const db = drizzle(env.DB, { schema });

--- a/src/app/_libs/db/schema/index.ts
+++ b/src/app/_libs/db/schema/index.ts
@@ -1,0 +1,5 @@
+import { users } from './tables/users';
+
+export const schema = {
+  users,
+};

--- a/src/app/_libs/db/schema/tables/users.ts
+++ b/src/app/_libs/db/schema/tables/users.ts
@@ -1,0 +1,10 @@
+import { text, sqliteTable } from 'drizzle-orm/sqlite-core';
+
+import type { InferModel } from 'drizzle-orm';
+
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey(),
+  name: text('name'),
+});
+
+export type User = InferModel<typeof users>;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+[[d1_databases]]
+binding = "DB"
+database_id = "local"
+database_name = "local"


### PR DESCRIPTION
close: #50 

# やったこと

D1のMigrationを作成/実行出来るようにしました。
`src/app/_libs/db/schema/tables`配下にDrizzleのSchemaを実装後、`pnpm run migrate:create`を実行する事でMigrationを作成できます。
Migration作成後は`pnpm run migrate:apply`を実行する事でMigrationをローカルで実行することが出来ます。

mainブランチへマージ後にProduction/Preview環境にMigrationを実行するCIを構築したのですが、Wrangler側の不具合?でGitHubActions上でMigrationを実行するとエラーが発生する為、一旦コメントアウトして動作しないようにしています。
https://github.com/looks-to-me/looks-to-me/pull/65/files#diff-9e794052ffc837d6f258ea584b3fc112aa43c97751c5e2277b6470ae4457d8bbR34-R35