### PR TITLE
[feature] Add a header component

### DIFF
--- a/.scaffdog/component.md
+++ b/.scaffdog/component.md
@@ -82,6 +82,7 @@ import type { ForwardRefRenderFunction , ComponentPropsWithoutRef } from 'react'
 {{- end }}
 
 export type {{ inputs.name | pascal }}Props = ComponentPropsWithoutRef<'div'> & {
+  // nothing
 };
 
 const {{ inputs.name | pascal }}Render: ForwardRefRenderFunction<HTMLDivElement, {{ inputs.name | pascal }}Props> = ({

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,9 @@ const nextConfig = {
       destination: '/storybook/index.htm',
     },
   ],
+  experimental: {
+    typedRoutes: true,
+  },
 };
 
 module.exports = withVanillaExtract(nextConfig);

--- a/src/app/_components/header/header.css.ts
+++ b/src/app/_components/header/header.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css';
+
+import { theme } from '../../_theme';
+
+export const wrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '16px',
+  padding: '16px',
+  borderBottom: `solid 1px ${theme.color.token.semantic.border}`,
+  backgroundColor: theme.color.token.semantic.backgroundInset,
+});
+
+export const link = style({
+  color: theme.color.token.semantic.text,
+  textDecoration: 'none',
+});
+
+export const logo = style({
+  fontSize: '1rem',
+  margin: 0,
+});

--- a/src/app/_components/header/header.stories.tsx
+++ b/src/app/_components/header/header.stories.tsx
@@ -1,0 +1,18 @@
+import { Header } from './header';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  component: Header,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as Meta<typeof Header>;
+
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    children: 'Header',
+  },
+};

--- a/src/app/_components/header/header.tsx
+++ b/src/app/_components/header/header.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx';
+import Link from 'next/link';
+import { forwardRef } from 'react';
+
+import * as styles from './header.css';
+
+import type { ForwardRefRenderFunction , ComponentPropsWithoutRef } from 'react';
+
+export type HeaderProps = ComponentPropsWithoutRef<'header'> & {
+  // nothing
+};
+
+const HeaderRender: ForwardRefRenderFunction<HTMLElement, HeaderProps> = ({
+  className,
+  children,
+  ...props
+}, ref) => {
+  return (
+    <header {...props} ref={ref} className={clsx(className, styles.wrapper)}>
+      <Link className={styles.link} href="/">
+        <h1 className={styles.logo}>
+          LooksToMe
+        </h1>
+      </Link>
+      <div>
+        {children}
+      </div>
+    </header>
+  );
+};
+
+export const Header = forwardRef<HTMLElement, HeaderProps>(HeaderRender);

--- a/src/app/_components/header/index.ts
+++ b/src/app/_components/header/index.ts
@@ -1,0 +1,1 @@
+export * from './header';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,17 @@
+import { Header } from './_components/header';
+
 import type { FC } from 'react';
 
 const HomePage: FC = () => {
   return (
-    <main>
-      LooksToMe
-    </main>
+    <div>
+      <Header>
+        Header
+      </Header>
+      <main>
+        MainContent
+      </main>
+    </div>
   );
 };
 


### PR DESCRIPTION
# やったこと

全てのページのベースとなるヘッダーコンポーネントを実装しました。
↓みたいな感じでページ毎にHeaderを実装していく想定です。
```tsx
const PostListPageHeader: FC = () => {
  return (
    <Header>
      // PostListPage固有のUI
    </Header>
  );
};
```