### PR TITLE
[feature] fix size and color of overlay iamge

### DIFF
--- a/src/app/(main)/images/overlays/[word]/route.tsx
+++ b/src/app/(main)/images/overlays/[word]/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/server';
+import * as z from 'zod';
 
 import type { NextRequest } from 'next/server';
 
@@ -6,63 +7,40 @@ export const runtime = 'edge';
 
 export const contentType = 'image/png';
 
-const isTooLong = (word: string) => word.length > 32;
+const colorSchema = z.union([z.literal('black'), z.literal('white')]).default('black');
+const wordSchema = z
+  .string()
+  .regex(/^[a-zA-Z]+$/, { message: 'Must be a alphabetic.' })
+  .max(32, { message: 'Must be less than 32 characters.' })
+  .transform((word) => `${word[0]?.toUpperCase()}${word.slice(1).toLowerCase()}`);
 
-const isAlphabetic = (word: string) => /^[a-zA-Z]+$/.test(word);
+export const GET = (request: NextRequest, { params }: { params: { word: string } }) => {
+  const word = wordSchema.safeParse(params.word);
+  if (!word.success) {
+    return new Response(word.error.message, { status: 400 });
+  }
 
-const normalize = (word: string) => {
-  return `${word[0]?.toUpperCase()}${word.slice(1).toLowerCase()}`;
-};
-
-const getColorQuery = (request: NextRequest) => {
   const { searchParams } = new URL(request.url);
-  const color = searchParams.get('color');
-  if (!color) {
-    // default color
-    return 'black';
-  }
-  if (color === 'white' || color === 'black') {
-    return color;
-  }
-  return null;
-};
-
-export const GET = (
-  request: NextRequest,
-  { params }: { params: { word: string } },
-) => {
-  if (isTooLong(params.word)) {
-    return new Response('word must be less than 32 characters', {
-      status: 400,
-    });
-  }
-  if (!isAlphabetic(params.word)) {
-    return new Response('word must be alphabetic', { status: 400 });
-  }
-  const word = normalize(params.word);
-
-  const color = getColorQuery(request);
-  if (!color) {
+  const color = colorSchema.safeParse(searchParams.get('color') ?? undefined);
+  if (!color.success) {
     return new Response('color must be white or black', { status: 400 });
   }
 
-  return new ImageResponse((
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      <div style={{ display: 'flex', fontSize: 200, color }}>
-        L{word.at(0)}TM
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <div style={{ display: 'flex', fontSize: 200, color: color.data }}>L{word.data.at(0)}TM</div>
+        <div style={{ display: 'flex', fontSize: 50, color: color.data }}>Looks {word.data} To Me</div>
       </div>
-      <div style={{ display: 'flex', fontSize: 50, color }}>
-        Looks {word} To Me
-      </div>
-    </div>
-  ));
+    ),
+  );
 };

--- a/src/app/(main)/images/overlays/[word]/route.tsx
+++ b/src/app/(main)/images/overlays/[word]/route.tsx
@@ -6,16 +6,45 @@ export const runtime = 'edge';
 
 export const contentType = 'image/png';
 
+const isTooLong = (word: string) => word.length > 32;
+
+const isAlphabetic = (word: string) => /^[a-zA-Z]+$/.test(word);
+
 const normalize = (word: string) => {
   return `${word[0]?.toUpperCase()}${word.slice(1).toLowerCase()}`;
 };
 
-// TODO: Font size, etc. must be adjusted.
+const getColorQuery = (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
+  const color = searchParams.get('color');
+  if (!color) {
+    // default color
+    return 'black';
+  }
+  if (color === 'white' || color === 'black') {
+    return color;
+  }
+  return null;
+};
+
 export const GET = (
-  _: NextRequest,
+  request: NextRequest,
   { params }: { params: { word: string } },
 ) => {
+  if (isTooLong(params.word)) {
+    return new Response('word must be less than 32 characters', {
+      status: 400,
+    });
+  }
+  if (!isAlphabetic(params.word)) {
+    return new Response('word must be alphabetic', { status: 400 });
+  }
   const word = normalize(params.word);
+
+  const color = getColorQuery(request);
+  if (!color) {
+    return new Response('color must be white or black', { status: 400 });
+  }
 
   return new ImageResponse((
     <div
@@ -28,10 +57,10 @@ export const GET = (
         height: '100%',
       }}
     >
-      <div style={{ display: 'flex' }}>
+      <div style={{ display: 'flex', fontSize: 200, color }}>
         L{word.at(0)}TM
       </div>
-      <div style={{ display: 'flex' }}>
+      <div style={{ display: 'flex', fontSize: 50, color }}>
         Looks {word} To Me
       </div>
     </div>

--- a/src/app/(main)/images/overlays/[word]/route.tsx
+++ b/src/app/(main)/images/overlays/[word]/route.tsx
@@ -7,7 +7,11 @@ export const runtime = 'edge';
 
 export const contentType = 'image/png';
 
-const colorSchema = z.union([z.literal('black'), z.literal('white')]).default('black');
+const colorSchema = z
+  .union([z.literal('black'), z.literal('white')], {
+    invalid_type_error: 'color must be white or black',
+  })
+  .default('black');
 const wordSchema = z
   .string()
   .regex(/^[a-zA-Z]+$/, { message: 'Must be a alphabetic.' })
@@ -23,7 +27,7 @@ export const GET = (request: NextRequest, { params }: { params: { word: string }
   const { searchParams } = new URL(request.url);
   const color = colorSchema.safeParse(searchParams.get('color') ?? undefined);
   if (!color.success) {
-    return new Response('color must be white or black', { status: 400 });
+    return new Response(color.error.message, { status: 400 });
   }
 
   return new ImageResponse(
@@ -38,8 +42,12 @@ export const GET = (request: NextRequest, { params }: { params: { word: string }
           height: '100%',
         }}
       >
-        <div style={{ display: 'flex', fontSize: 200, color: color.data }}>L{word.data.at(0)}TM</div>
-        <div style={{ display: 'flex', fontSize: 50, color: color.data }}>Looks {word.data} To Me</div>
+        <div style={{ display: 'flex', fontSize: 200, color: color.data }}>
+          L{word.data.at(0)}TM
+        </div>
+        <div style={{ display: 'flex', fontSize: 50, color: color.data }}>
+          Looks {word.data} To Me
+        </div>
       </div>
     ),
   );

--- a/src/app/(main)/images/overlays/[word]/route.tsx
+++ b/src/app/(main)/images/overlays/[word]/route.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/server';
-import * as z from 'zod';
+import { z } from 'zod';
 
 import type { NextRequest } from 'next/server';
 


### PR DESCRIPTION
## やったこと

- 文字数制限を入れた（最大で32文字）
- 文字種別の制限を入れた（アルファベットのみ）
- 色を指定できるようにした（今は white or black のみ。指定がなければblack。）
- 文字のサイズをいい感じに調整した。画像サイズは固定で返すまま。

## 動作確認

`https://feature-images-overlays-endp.looks-to-me.pages.dev/images/overlays/{最大32文字のアルファベット}?color={white or black}` に対してリクエストを送ると、文字列の画像が生成されます。