### PR TITLE
[feature] displayNameをnullableにした

### DIFF
--- a/migrations/0003_tired_onslaught.sql
+++ b/migrations/0003_tired_onslaught.sql
@@ -1,0 +1,8 @@
+/*
+ SQLite does not support "Drop not null from column" out of the box, we do not generate automatic migration for that, so it has to be done manually
+ Please refer to: https://www.techonthenet.com/sqlite/tables/alter_table.php
+                  https://www.sqlite.org/lang_altertable.html
+                  https://stackoverflow.com/questions/2083543/modify-a-columns-type-in-sqlite3
+
+ Due to that we don't generate migration automatically and it has to be done manually
+*/

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,182 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "81031810-2925-40a8-96ba-b71760cd3a57",
+  "prevId": "68e43271-6d01-4739-9003-e7c49a23fff5",
+  "tables": {
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "images_user_id_users_id_fk": {
+          "name": "images_user_id_users_id_fk",
+          "tableFrom": "images",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_image_id_word_unique": {
+          "name": "posts_image_id_word_unique",
+          "columns": [
+            "image_id",
+            "word"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_users_id_fk": {
+          "name": "posts_user_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_image_id_images_id_fk": {
+          "name": "posts_image_id_images_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1692065530244,
       "tag": "0002_violet_malcolm_colcord",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1692479048768,
+      "tag": "0003_tired_onslaught",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(main)/_components/sync-o-auth-user/sync-o-auth-user.tsx
+++ b/src/app/(main)/_components/sync-o-auth-user/sync-o-auth-user.tsx
@@ -11,13 +11,14 @@ import type { FC } from 'react';
 export const SyncOAuthUser: FC = () => {
   const user = useUser();
   const previous = usePrevious(user);
+  console.log({ user });
 
   useEffect(() => {
     if (user && !previous) {
       void upsertUser({
         id: user.id,
         accountName: user.user_metadata['user_name'],
-        displayName: user.user_metadata['name'],
+        displayName: user.user_metadata['name'] ?? null,
         avatarUrl: user.user_metadata['avatar_url'],
       });
     }

--- a/src/app/(main)/_components/sync-o-auth-user/sync-o-auth-user.tsx
+++ b/src/app/(main)/_components/sync-o-auth-user/sync-o-auth-user.tsx
@@ -11,7 +11,6 @@ import type { FC } from 'react';
 export const SyncOAuthUser: FC = () => {
   const user = useUser();
   const previous = usePrevious(user);
-  console.log({ user });
 
   useEffect(() => {
     if (user && !previous) {

--- a/src/app/_libs/auth/server/get-auth-user.ts
+++ b/src/app/_libs/auth/server/get-auth-user.ts
@@ -9,7 +9,7 @@ export const getAuthUser = async (): Promise<AuthUser | undefined> => {
   return AuthUserSchema.parse({
     id: user.id,
     accountName: user.user_metadata['user_name'],
-    displayName: user.user_metadata['name'],
+    displayName: user.user_metadata['name'] ?? null,
     avatarUrl: user.user_metadata['avatar_url'],
   });
 };

--- a/src/app/_libs/auth/type/auth-user.ts
+++ b/src/app/_libs/auth/type/auth-user.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const AuthUserSchema = z.object({
   id: z.string(),
   accountName: z.string(),
-  displayName: z.string(),
+  displayName: z.string().nullable(),
   avatarUrl: z.string(),
 });
 

--- a/src/app/_libs/db/schema/tables/users.ts
+++ b/src/app/_libs/db/schema/tables/users.ts
@@ -9,7 +9,7 @@ import type { InferModel } from 'drizzle-orm';
 export const users = sqliteTable('users', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
-  displayName: text('display_name').notNull(),
+  displayName: text('display_name'),
   avatarUrl: text('avatar_url').notNull(),
   registeredAt: integer('registered_at', { mode: 'timestamp_ms' }).notNull(),
 });


### PR DESCRIPTION
https://praha-inc.slack.com/archives/C05AA4932KW/p1692464412313049?thread_ts=1692457305.706899&cid=C05AA4932KW

githubから返ってくる値`name`が空である場合がある

- dbのカラムをnullableにした
- [`AuthUserSchema`](https://github.com/looks-to-me/looks-to-me/blob/fd3e61dd507af38e0276204ec904aae9d6619d6a/src/app/_libs/auth/type/auth-user.ts#L3)の`displayName`をnullableにした

`name`が空の場合`user_name`にfallbackする案もあったが、そこはUIに委ねたほうがいいと思ったのでやらなかった
`name`と`user_name`がとなりあって並ぶようなUIがあった場合、`gn-t-k gn-t-k`みたいになってしまい、それなら`name`の方は表示しない、という選択ができる