### PR TITLE
[bugfix] Set width to svg logo

### DIFF
--- a/app/src/app/(main)/_components/application-logo/application-logo.tsx
+++ b/app/src/app/(main)/_components/application-logo/application-logo.tsx
@@ -29,9 +29,9 @@ const ApplicationLogoRender: ForwardRefRenderFunction<HTMLAnchorElement, Applica
             <div className={styles.icon}>
               <AccessibleIcon label="LooksToMe">
                 {withText ? (
-                  <LooksToMeWithTextBlack width="auto" height="auto" />
+                  <LooksToMeWithTextBlack width="100%" height="auto" />
                 ) : (
-                  <LooksToMeBlack width="auto" height="auto" />
+                  <LooksToMeBlack width="100%" height="auto" />
                 )}
               </AccessibleIcon>
             </div>
@@ -40,9 +40,9 @@ const ApplicationLogoRender: ForwardRefRenderFunction<HTMLAnchorElement, Applica
             <div className={styles.icon}>
               <AccessibleIcon label="LooksToMe">
                 {withText ? (
-                  <LooksToMeWithTextWhite width="auto" height="auto" />
+                  <LooksToMeWithTextWhite width="100%" height="auto" />
                 ) : (
-                  <LooksToMeWhite width="auto" height="auto" />
+                  <LooksToMeWhite width="100%" height="auto" />
                 )}
               </AccessibleIcon>
             </div>


### PR DESCRIPTION
safari doesn't seem to display if svg doesn't have width (or height)

before

<img width="970" alt="Screenshot 2023-09-04 at 0 52 24" src="https://github.com/looks-to-me/looks-to-me/assets/45958851/87098181-c7cb-4c8e-a76d-e6e34cfd04d6">

after

<img width="960" alt="Screenshot 2023-09-04 at 0 51 11" src="https://github.com/looks-to-me/looks-to-me/assets/45958851/cb919cd4-1a33-4329-bd59-9e6661e2c16a">