### PR TITLE
Refactor Drizzle database type to that of D1

### DIFF
--- a/apps/web/src/app/_libs/database/instance/index.ts
+++ b/apps/web/src/app/_libs/database/instance/index.ts
@@ -3,9 +3,9 @@ import { drizzle } from 'drizzle-orm/d1';
 import { privateEnv } from '../../env';
 import { schema } from '../schema';
 
-import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
+import type { DrizzleD1Database } from 'drizzle-orm/d1';
 
-export type Database = BaseSQLiteDatabase<'async', unknown, typeof schema>;
+export type Database = DrizzleD1Database<typeof schema>;
 
 let instance: Database | undefined;
 


### PR DESCRIPTION
変更点
- D1用の型に変更

トランザクション用の`batch`という関数が表示されなかったので「なんで？」と思って調べたら、型がD1用じゃないっぽかったので修正しました。
参考：[Cloudflare D1でのトランザクションと、Drizzle ORMの対応 | Memory ice cubes](https://leaysgur.github.io/posts/2023/10/17/213948/)