### PR TITLE
Add mutation to delete user

### DIFF
--- a/apps/web/src/app/_libs/database/helpers/index.ts
+++ b/apps/web/src/app/_libs/database/helpers/index.ts
@@ -21,8 +21,8 @@ export const migrate = async (database: Database) => {
 };
 
 export const truncate = async (database: Database) => {
-  await database.delete(schema.posts);
   await database.delete(schema.postTags);
+  await database.delete(schema.posts);
   await database.delete(schema.images);
   await database.delete(schema.tags);
   await database.delete(schema.muteUsers);

--- a/apps/web/src/app/_libs/database/seed/create-production-like-test-data.test.ts
+++ b/apps/web/src/app/_libs/database/seed/create-production-like-test-data.test.ts
@@ -1,0 +1,28 @@
+import { createProductionLikeUserData } from './create-production-like-test-data';
+import { database } from '..';
+import { setupDatabase } from '../../test/setup-database';
+import { setupWorker } from '../../test/setup-worker';
+import { schema } from '../schema';
+
+type NonRelationsKeys<T extends string> = {
+  [K in T]: K extends `${infer R}Relations` ? R : never;
+}[T];
+type TableName = NonRelationsKeys<keyof typeof schema>;
+
+describe('insert-production-like-test-data', () => {
+  setupWorker();
+  setupDatabase();
+
+  it('should at least one record exist in all tables', async () => {
+    await createProductionLikeUserData();
+
+    const tableNames = Object.keys(schema).filter(
+      (tableName) => !tableName.includes('Relations'),
+    ) as unknown as TableName[];
+
+    for (const tableName of tableNames) {
+      const result = await database().select().from(schema[tableName]).all();
+      expect(result.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/apps/web/src/app/_libs/database/seed/create-production-like-test-data.ts
+++ b/apps/web/src/app/_libs/database/seed/create-production-like-test-data.ts
@@ -1,0 +1,84 @@
+import { createId } from '@paralleldrive/cuid2';
+
+import { database } from '..';
+import { schema } from '../schema';
+
+import type { MuteUser } from '../../../../repositories/mute-user-repository';
+
+export const createProductionLikeUserData = async () => {
+  const userId = createId();
+  const user = await database().insert(schema.users).values({
+    id: userId,
+    registeredAt: new Date(),
+  }).returning().get();
+  
+  const userProfile = await database().insert(schema.userProfiles).values({
+    avatarUrl:'avatarUrl',
+    displayName:'displayName',
+    name:'name',
+    userId,
+  }).returning().get();
+  
+  const userProvider = await database().insert(schema.userProviders).values({
+    sub: `sub-${userId}`,
+    type: 'github',
+    userId,
+  }).returning().get();
+  
+  const imageId = createId();
+  const image = await database().insert(schema.images).values({
+    id: imageId,
+    userId,
+    height: 100,
+    width: 100,
+    uploadedAt: new Date(),
+  }).returning().get();
+  
+  const postId = createId();
+  const post = await database().insert(schema.posts).values({
+    id: postId,
+    userId,
+    imageId,
+    postedAt: new Date(),
+    word: 'word',
+  }).returning().get();
+  
+  const otherUserId = createId();
+  const otherUser = await database().insert(schema.users).values({
+    id: otherUserId,
+    registeredAt: new Date(),
+  }).returning().get();
+  
+  const muteUsers: MuteUser[] = [{
+    userId: otherUserId,
+    muteUserId: userId,
+  },{
+    userId,
+    muteUserId: otherUserId,
+  }];
+  await database().insert(schema.muteUsers).values(muteUsers);
+
+  const tagId = createId();
+  const tag = await database().insert(schema.tags).values({
+    id: tagId,
+    name:'tag',
+  }).returning().get();
+
+  const postTag = await database().insert(schema.postTags).values({
+    order: 0,
+    postId,
+    tagId,
+  }).returning().get();
+
+  return{
+    user,
+    userProfile,
+    userProvider,
+    image,
+    post,
+    otherUser,
+    muteUsers,
+    tag,
+    postTag,
+  };
+}; 

--- a/apps/web/src/mutations/user/delete-user-permanently.test.ts
+++ b/apps/web/src/mutations/user/delete-user-permanently.test.ts
@@ -1,0 +1,98 @@
+import { eq } from 'drizzle-orm';
+
+import { deleteUserPermanently } from './delete-user-permanently';
+import { getUserMetadata } from '../../app/_libs/auth/server/get-user-metadata';
+import { database } from '../../app/_libs/database';
+import { schema } from '../../app/_libs/database/schema';
+import { createProductionLikeUserData } from '../../app/_libs/database/seed/create-production-like-test-data';
+import { setupDatabase } from '../../app/_libs/test/setup-database';
+import { setupWorker } from '../../app/_libs/test/setup-worker';
+
+import type { DeleteUserPermanentlyResult } from './delete-user-permanently';
+import type { UserMetadata } from '../../app/_libs/auth/type/user-metadata';
+
+jest.mock('@supabase/auth-helpers-nextjs');
+jest.mock('../../app/_libs/auth/server/get-user-metadata');
+jest.mock('next/cache');
+
+const getUserDataByUserId = async (userId: string) => {
+  return await Promise.all([
+    database().select().from(schema.users).where(eq(schema.users.id, userId)).get(),
+    database().select().from(schema.images).where(eq(schema.images.userId, userId)).get(),
+    database().select().from(schema.muteUsers).where(eq(schema.muteUsers.userId, userId)).get(),
+    database().select().from(schema.muteUsers).where(eq(schema.muteUsers.muteUserId, userId)).get(),
+    database().select().from(schema.posts).where(eq(schema.posts.userId, userId)).get(),
+    database().select().from(schema.userProfiles).where(eq(schema.userProfiles.userId, userId)).get(),
+    database().select().from(schema.userProviders).where(eq(schema.userProviders.userId, userId)).get(),
+  ]);
+};
+
+describe('delete-user-permanently', () => {
+  setupWorker();
+  setupDatabase();
+  let userId1: string;
+  let userId2: string;
+  beforeEach(async () => {
+    const { user: user1 } = await createProductionLikeUserData();
+    const { user: user2 } = await createProductionLikeUserData();
+    userId1 = user1.id;
+    userId2 = user2.id;
+
+  });
+  describe('when not logged in', () => {
+    beforeEach(() => {
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      jest.mocked(getUserMetadata).mockResolvedValue(undefined);
+    });
+
+    it('should return error if unauthorized', async () => {
+      const result = await deleteUserPermanently();
+      expect(result).toEqual({
+        type:'error',
+        reason: 'unauthorized',
+        message: expect.any(String),
+      } satisfies DeleteUserPermanentlyResult);
+    });
+  });
+
+  describe('when logged in', () => {
+    beforeEach(() => {
+      jest.mocked(getUserMetadata).mockResolvedValue({
+        provider: 'github',
+        sub: `sub-${userId1}`,
+        name: 'name',
+        user_name: 'user_name',
+        avatar_url: 'avatar_url',
+      } satisfies UserMetadata);
+    });
+
+    it('should delete all data for user1 and not delete data for user2.', async () => {
+      const user1DataBeforeDelete = await getUserDataByUserId(userId1);
+      for (const datum of user1DataBeforeDelete) {
+        expect(datum).toBeDefined();
+      }
+      const user2DataBeforeDelete = await getUserDataByUserId(userId1);
+      for (const datum of user2DataBeforeDelete) {
+        expect(datum).toBeDefined();
+      }
+
+      const result = await deleteUserPermanently();
+
+      expect(result).toEqual({
+        type:'success',
+        message: expect.any(String),
+      } satisfies DeleteUserPermanentlyResult);
+
+      const user1DataAfterDelete = await getUserDataByUserId(userId1);
+      for (const datum of user1DataAfterDelete) {
+        expect(datum).toBeUndefined();
+      }
+
+      const user2DataAfterDelete = await getUserDataByUserId(userId2);
+      for (const datum of user2DataAfterDelete) {
+        expect(datum).toBeDefined();
+      }
+    });
+  });
+
+});

--- a/apps/web/src/mutations/user/delete-user-permanently.ts
+++ b/apps/web/src/mutations/user/delete-user-permanently.ts
@@ -1,0 +1,81 @@
+'use server';
+
+import { deleteImageCache } from '@looks-to-me/package-image-cache';
+import { eq, inArray, or } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+
+import { database } from '../../app/_libs/database';
+import { schema } from '../../app/_libs/database/schema';
+import { privateEnv } from '../../app/_libs/env';
+import { getLoginUser } from '../../queries/user/get-login-user';
+
+export type DeleteUserPermanentlyResult =
+  | {
+    type: 'success';
+    message: `Your account(@${string}) has been successfully deleted.`;
+  }
+  | {
+    type: 'error';
+    reason: 'databaseError' | 'unauthorized';
+    message: string;
+  };
+
+export const deleteUserPermanently =
+  async (): Promise<DeleteUserPermanentlyResult> => {
+    const user = await getLoginUser();
+    if (!user) return { type: 'error', reason: 'unauthorized', message: 'Login required!' };
+
+    const posts = await database()
+      .select({ id: schema.posts.id })
+      .from(schema.posts)
+      .where(eq(schema.posts.userId, user.id))
+      .all();
+    const postIds = posts.map((post) => post.id);
+
+    // TODO: Make use of transaction or batch.
+    // @see: https://github.com/drizzle-team/drizzle-orm/issues/758
+    await database()
+      .delete(schema.postTags)
+      .where(inArray(schema.postTags.postId, postIds));
+
+    await database()
+      .delete(schema.posts)
+      .where(eq(schema.posts.userId, user.id));
+
+    await database().delete(schema.images).where(eq(schema.images.userId, user.id)),
+
+    await database()
+      .delete(schema.muteUsers)
+      .where(
+        or(
+          eq(schema.muteUsers.userId, user.id),
+          eq(schema.muteUsers.muteUserId, user.id),
+        ),
+      ),
+
+    await database()
+      .delete(schema.userProfiles)
+      .where(eq(schema.userProfiles.userId, user.id)),
+
+    await database()
+      .delete(schema.userProviders)
+      .where(eq(schema.userProviders.userId, user.id)),
+
+    await database().delete(schema.users).where(eq(schema.users.id, user.id));
+
+    for (const postId of postIds) {
+      void deleteImageCache({
+        bucket: privateEnv().BUCKET,
+        path: `images/posts/${postId}`,
+      });
+    }
+
+    revalidatePath('/');
+    revalidatePath('/shuffle');
+    revalidatePath(`/@${user.profile.name}`);
+    
+    return {
+      type: 'success',
+      message: `Your account(@${user.profile.name}) has been successfully deleted.`,
+    };
+  };


### PR DESCRIPTION
## 変更点
- 以下のタスクに必要なmutationを追加した
- #2 


## 補足
`create-production-like-test-data.ts`を追加した理由は、本番で`delete-user-permanently.ts`を実行した際に外部キーエラーが起きないようにするためです！

たとえば、postIdを外部キーとするテーブルが新しくできちゃった場合、「テストでは成功するのに本番では失敗する」みたいなことになっちゃいます🤔

なので、
`create-production-like-test-data.ts`でデモデータを作り、
`create-production-like-test-data.test.ts`で「全テーブルに最低でも1レコードある」をテストするようにしました。

こうすると、本番と同様のデータで`delete-user-permanently.ts`もチェックできると考えました。