### PR TITLE
Add title to Mute user list on settings page

### DIFF
--- a/apps/web/src/app/(main)/settings/(home)/@main/page.css.ts
+++ b/apps/web/src/app/(main)/settings/(home)/@main/page.css.ts
@@ -5,3 +5,9 @@ export const wrapper = style({
   maxWidth: '600px',
   margin: '0 auto',
 });
+
+export const title = style({
+  fontWeight: '400',
+  fontSize:' 1.5rem',
+  margin: '0 0 10px 0',
+});

--- a/apps/web/src/app/(main)/settings/(home)/@main/page.tsx
+++ b/apps/web/src/app/(main)/settings/(home)/@main/page.tsx
@@ -22,7 +22,7 @@ const SettingsHomeMainPage: FC<SettingsHomeMainPageProps> = async () => {
   
   return (
     <div className={styles.wrapper}>
-      {/* TODO: Add SettingTitle Component. */}
+      <h2 className={styles.title}>Muted Users</h2>
       <UserMuteList users={users} />
     </div>
   );

--- a/apps/web/src/components/domains/user/user-mute-list/user-mute-list.css.ts
+++ b/apps/web/src/components/domains/user/user-mute-list/user-mute-list.css.ts
@@ -8,12 +8,15 @@ export const mutedWrapper = style({
   border: `solid 1px ${theme.color.token.semantic.border}`,
   borderRadius: theme.size.radius.medium,
   paddingLeft: '0',
+  margin: '0',
 });
 
 export const notMutedWrapper = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  border: `solid 1px ${theme.color.token.semantic.border}`,
+  borderRadius: theme.size.radius.medium,
   height: '100px',
   width: '100%',
   fontWeight: '600',


### PR DESCRIPTION
## 変更後
ミュートユーザーがいる場合👇
![2023-12-26_20h11_48](https://github.com/looks-to-me/looks-to-me/assets/53581722/f71e7f10-a62a-4c91-91cb-9f7ed6225f40)

ミュートユーザーがいない場合👇（枠をつけた）
![2023-12-26_20h11_57](https://github.com/looks-to-me/looks-to-me/assets/53581722/dc82845c-3b85-4e0f-b55a-c85e514b9044)

## そのほか
設定項目が増えたときのために、`SettingTitle`みたいなコンポーネントを追加しようと思ってたのですが
増えたタイミングで追加した方がいいかと思ったのでやめました。

なので単純に`h2`を追加しました！